### PR TITLE
simplify mount function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,8 @@ import TestUtils from "react-dom/test-utils";
 
 export function mount(element) {
   const div = document.createElement('div');
-  ReactDOM.render(element, div);
-  return div;
+  ReactDom.render(element, div);
+  return div.firstChild;
 }
 
 export { Simulate } from "react-dom/test-utils";

--- a/src/index.js
+++ b/src/index.js
@@ -3,24 +3,10 @@ import PropTypes from "prop-types";
 import ReactDom from "react-dom";
 import TestUtils from "react-dom/test-utils";
 
-class StatelessWrapper extends Component {
-  render() {
-    return this.props.children;
-  }
-}
-
-StatelessWrapper.propTypes = {
-  children: PropTypes.element.isRequired
-};
-
-export function mount(component) {
-  const rendered =
-    TestUtils.renderIntoDocument(component) ||
-    TestUtils.renderIntoDocument(
-      <StatelessWrapper>{component}</StatelessWrapper>
-    );
-
-  return ReactDom.findDOMNode(rendered);
+export function mount(element) {
+  const div = document.createElement('div');
+  ReactDOM.render(element, div);
+  return div;
 }
 
 export { Simulate } from "react-dom/test-utils";


### PR DESCRIPTION
If you look into what TestUtils is doing, this is basically it. The only reason you have to create a class component and use findDOMNode is because they don't return the `div` back to you. If you just do things this way then you don't need to bother with a class component.

I also renamed it to `element` because that's more accurate.