### PR TITLE
Add unmount to the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ Renders a React component into the DOM and returns the DOM node.
 const node = mount(<Hello>Jane Doe</Hello>);
 ```
 
+### unmount
+
+Unmount a mounted component from the DOM. 
+
+You normally don't need to unmount components, it is only when your component has some side-effect that messes with the environment, like writing to the HTML body the unmount need to run to clean up. That of cause depends on the component actually cleaning up after itself.
+
+```js
+const node = mount(<Hello>Jane Doe</Hello>);
+unmount(node);
+```
+
 ### simulate
 
 A function to simulate one or more events using `Simulate` object from

--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
     "eslint-plugin-prettier": "2.6.0",
     "jest": "23.6.0",
     "prettier": "1.11.1",
-    "prop-types": "15.6.1",
+    "prop-types": "15.6.2",
     "react": "16.2.0",
-    "react-dom": "16.2.0",
-    "sinon": "6.3.4",
-    "unexpected": "10.37.2",
-    "unexpected-dom": "4.5.0",
-    "unexpected-sinon": "10.10.1"
+    "react-dom": "16.2.1",
+    "sinon": "7.2.3",
+    "unexpected": "11.0.1",
+    "unexpected-dom": "4.11.1",
+    "unexpected-sinon": "10.11.0"
   },
   "peerDependencies": {
     "react": "^15.5.4 || 16",

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,13 @@ import { Simulate } from "react-dom/test-utils";
 import domspace from "domspace";
 
 export function mount(element) {
-  const div = document.createElement("div");
-  ReactDom.render(element, div);
-  return div.firstChild;
+  const container = document.createElement("div");
+  ReactDom.render(element, container);
+  return container.firstChild;
+}
+
+export function unmount(element) {
+  ReactDom.unmountComponentAtNode(element.parentNode);
 }
 
 export function simulate(rootElement, events) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,7 +5,7 @@ import unexpected from "unexpected";
 import unexpectedDom from "unexpected-dom";
 import unexpectedSinon from "unexpected-sinon";
 
-import { mount, simulate, Ignore } from "../src";
+import { mount, unmount, simulate, Ignore } from "../src";
 
 const expect = unexpected
   .clone()
@@ -24,6 +24,22 @@ class Hello extends Component {
         </div>
       </div>
     );
+  }
+}
+
+class DomFiddler extends Component {
+  componentWillMount() {
+    this.div = document.createElement("div");
+    this.div.setAttribute("data-test-id", "portal");
+    document.body.appendChild(this.div);
+  }
+
+  componentWillUnmount() {
+    document.body.removeChild(this.div);
+  }
+
+  render() {
+    return <div />;
   }
 }
 
@@ -82,6 +98,26 @@ describe("react-dom-test", () => {
         node.querySelector("[data-test=value]").textContent,
         "to equal",
         "Jane Doe"
+      );
+    });
+  });
+
+  describe("unmount", () => {
+    it("unmounts a mounted component", () => {
+      const component = mount(<DomFiddler />);
+
+      expect(
+        document.body,
+        "to contain elements matching",
+        "[data-test-id=portal]"
+      );
+
+      unmount(component);
+
+      expect(
+        document.body,
+        "to contain no elements matching",
+        "[data-test-id=portal]"
       );
     });
   });


### PR DESCRIPTION
It is sometimes useful to being able to unmount a component that you have mounted. This is mainly for situations where the mounted component has some side-effects that needs to be cleaned up when unmounted. As an example this could be situations where the component write to the HTML body or attaches event listeners outside the component.