### PR TITLE
Expose act and show how we can test async components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
   extends: ["pretty-standard"],
+  globals: {
+    jest: false
+  },
   plugins: ["prettier", "import"],
   rules: {
     "prettier/prettier": "error",

--- a/README.md
+++ b/README.md
@@ -193,6 +193,28 @@ expect(
 );
 ```
 
+### act
+
+This is just the https://reactjs.org/docs/test-utils.html#act
+
+`act` is useful when you need to force a state transition like resolving a mocked promise:
+
+```js
+it("supports asynchronous components", () => {
+  const component = mount(<PromisedAnswer />);
+
+  expect(component, "to have text", "Waiting...");
+
+  act(() => {
+    fakePromise.resolve("wat");
+  });
+
+  expect(component, "to have text", "wat");
+});
+```
+
+See the tests for more details.
+
 ## License
 
 [MIT © Sune Simonsen](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-config-pretty-standard": "1.3.0",
     "eslint-plugin-import": "2.9.0",
     "eslint-plugin-prettier": "2.6.0",
+    "fake-promise": "2.3.2",
     "jest": "23.6.0",
     "prettier": "1.11.1",
     "prop-types": "15.6.2",

--- a/src/index.js
+++ b/src/index.js
@@ -67,5 +67,5 @@ export function simulate(rootElement, events) {
     });
 }
 
-export { Simulate } from "react-dom/test-utils";
+export { act, Simulate } from "react-dom/test-utils";
 export { default as Ignore } from "./Ignore";

--- a/test/fetchAnswer.js
+++ b/test/fetchAnswer.js
@@ -1,0 +1,3 @@
+const fetchAnswer = () => Promise.resolve("42");
+
+export default fetchAnswer;


### PR DESCRIPTION
I'm seeing some problems around testing async flows with React hooks at work and on the interwebs. So I added some example tests and exposed `act` on the API as that is needed in this case.