### PR TITLE
Mounting a React fragment returns a DOM document fragment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,19 @@ export function mount(element) {
     ReactDom.render(element, container);
   }
 
-  return container.firstChild;
+  const childNodes = container.childNodes;
+
+  if (childNodes.length === 1) {
+    return childNodes[0];
+  } else {
+    const documentFragment = document.createDocumentFragment();
+
+    for (let i = 0; i < childNodes.length; i += 1) {
+      documentFragment.appendChild(childNodes[i].cloneNode(true));
+    }
+
+    return documentFragment;
+  }
 }
 
 export function unmount(element) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -163,6 +163,28 @@ describe("react-dom-testing", () => {
         "Jane Doe"
       );
     });
+
+    describe("when given a React fragment", () => {
+      it("returns a HTML document fragment", () => {
+        const Fragmented = () => (
+          <React.Fragment>
+            <h1>Fragmentation</h1>
+            <p>Everything is just so fragmented</p>
+          </React.Fragment>
+        );
+
+        expect(
+          mount(<Fragmented />),
+          "to satisfy",
+          mount(
+            <React.Fragment>
+              <h1>Fragmentation</h1>
+              <p>Everything is just so fragmented</p>
+            </React.Fragment>
+          )
+        ).and("to be a", "DOMDocumentFragment");
+      });
+    });
   });
 
   describe("unmount", () => {


### PR DESCRIPTION
This will allow you to use React fragments without wrapping them in a an element.

