### PR TITLE
Return null for empty fragments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dom-testing",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "A minimal React DOM testing utility",
   "main": "./lib/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,9 @@ export function mount(element) {
 
   const childNodes = container.childNodes;
 
-  if (childNodes.length === 1) {
+  if (childNodes.length === 0) {
+    return null;
+  } else if (childNodes.length === 1) {
     return childNodes[0];
   } else {
     const documentFragment = document.createDocumentFragment();

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -187,6 +187,14 @@ describe("react-dom-testing", () => {
     });
   });
 
+  describe("when given an empty React fragment", () => {
+    it("returns null", () => {
+      const Fragmented = () => <React.Fragment />;
+
+      expect(mount(<Fragmented />), "to be null");
+    });
+  });
+
   describe("unmount", () => {
     it("unmounts a mounted component", () => {
       const component = mount(<DomFiddler />);


### PR DESCRIPTION
I missed this case when I started rendering React fragments as DOM fragments.